### PR TITLE
Revamp schedule page layout and styling

### DIFF
--- a/css/schedule.css
+++ b/css/schedule.css
@@ -1,0 +1,336 @@
+.schedule_intro {
+    position: relative;
+    background: linear-gradient(135deg, #1c3faa 0%, #3c8ce7 40%, #00d2ff 100%);
+    color: #ffffff;
+    overflow: hidden;
+}
+
+.schedule_intro::before,
+.schedule_intro::after {
+    content: "";
+    position: absolute;
+    border-radius: 50%;
+    opacity: 0.18;
+    background: #ffffff;
+}
+
+.schedule_intro::before {
+    width: 320px;
+    height: 320px;
+    top: -160px;
+    right: -120px;
+}
+
+.schedule_intro::after {
+    width: 240px;
+    height: 240px;
+    bottom: -120px;
+    left: -80px;
+}
+
+.schedule_intro .section_title span {
+    letter-spacing: 0.32em;
+    text-transform: uppercase;
+    font-weight: 600;
+    color: rgba(255, 255, 255, 0.75);
+}
+
+.schedule_intro .section_title h3 {
+    font-size: 2.75rem;
+    line-height: 1.2;
+    margin-bottom: 24px;
+}
+
+.schedule_intro .section_title p {
+    max-width: 720px;
+    margin: 0 auto;
+    color: rgba(255, 255, 255, 0.85);
+    font-size: 1.05rem;
+    line-height: 1.7;
+}
+
+.schedule_filters {
+    margin-top: -90px;
+    position: relative;
+    z-index: 2;
+}
+
+.schedule_filters .filter_buttons {
+    background: #ffffff;
+    border-radius: 24px;
+    padding: 28px 32px;
+    box-shadow: 0 25px 60px rgba(20, 44, 96, 0.12);
+    display: flex;
+    flex-wrap: wrap;
+    gap: 14px;
+    justify-content: center;
+}
+
+.filter_btn {
+    border: 1px solid rgba(44, 93, 198, 0.28);
+    background: transparent;
+    color: #1f2b6c;
+    padding: 12px 20px;
+    border-radius: 999px;
+    font-weight: 600;
+    font-size: 0.95rem;
+    letter-spacing: 0.01em;
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    transition: all 0.3s ease;
+    cursor: pointer;
+    box-shadow: none;
+}
+
+.filter_btn .filter_icon {
+    width: 34px;
+    height: 34px;
+    border-radius: 50%;
+    background: rgba(44, 93, 198, 0.12);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #2d6cdf;
+    font-size: 0.95rem;
+    transition: all 0.3s ease;
+}
+
+.filter_btn:hover,
+.filter_btn:focus {
+    border-color: transparent;
+    background: rgba(60, 140, 231, 0.08);
+    color: #1a2563;
+    outline: none;
+}
+
+.filter_btn:hover .filter_icon,
+.filter_btn:focus .filter_icon {
+    background: rgba(44, 93, 198, 0.2);
+}
+
+.filter_btn.active {
+    background: linear-gradient(135deg, #1c3faa 0%, #3c8ce7 80%);
+    color: #ffffff;
+    border-color: transparent;
+    box-shadow: 0 16px 30px rgba(28, 63, 170, 0.35);
+}
+
+.filter_btn.active .filter_icon {
+    background: rgba(255, 255, 255, 0.22);
+    color: #ffffff;
+}
+
+.schedule_events {
+    background: linear-gradient(180deg, #f7f9ff 0%, #ffffff 40%);
+    position: relative;
+    z-index: 1;
+}
+
+.schedule_events .row {
+    row-gap: 30px;
+}
+
+.schedule_item {
+    display: flex;
+}
+
+.schedule_card {
+    --schedule-accent: #3c8ce7;
+    --schedule-accent-soft: rgba(60, 140, 231, 0.16);
+    background: #ffffff;
+    border-radius: 26px;
+    padding: 28px;
+    box-shadow: 0 24px 55px rgba(15, 35, 95, 0.08);
+    border: 1px solid rgba(30, 60, 114, 0.06);
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+    position: relative;
+    width: 100%;
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.schedule_card::before {
+    content: "";
+    position: absolute;
+    inset: 26px auto 26px 0;
+    width: 6px;
+    border-radius: 99px;
+    background: var(--schedule-accent);
+}
+
+.schedule_card:hover {
+    transform: translateY(-8px);
+    box-shadow: 0 28px 65px rgba(15, 35, 95, 0.16);
+}
+
+.schedule_card_header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 16px;
+}
+
+.schedule_badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 0.75rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    border-radius: 999px;
+    padding: 8px 18px;
+    background: var(--schedule-accent-soft);
+    color: var(--schedule-accent);
+    white-space: nowrap;
+}
+
+.schedule_badge i {
+    font-size: 0.9rem;
+}
+
+.schedule_time {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    font-weight: 600;
+    color: #1f2b6c;
+}
+
+.schedule_time i {
+    color: var(--schedule-accent);
+}
+
+.schedule_card_body {
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+}
+
+.schedule_card_body .event_date {
+    display: inline-flex;
+    align-items: center;
+    justify-content: flex-start;
+    padding: 7px 16px;
+    border-radius: 999px;
+    background: var(--schedule-accent-soft);
+    color: var(--schedule-accent);
+    font-weight: 600;
+    font-size: 0.85rem;
+    width: max-content;
+}
+
+.schedule_card_body h4 {
+    font-size: 1.35rem;
+    line-height: 1.4;
+    color: #1c2454;
+    margin-bottom: 0;
+}
+
+.schedule_card_body p {
+    margin-bottom: 0;
+    color: #4f5f85;
+    line-height: 1.7;
+}
+
+.schedule_item[data-type="mass"] .schedule_card {
+    --schedule-accent: #3c8ce7;
+    --schedule-accent-soft: rgba(60, 140, 231, 0.16);
+}
+
+.schedule_item[data-type="wedding"] .schedule_card {
+    --schedule-accent: #f26d9b;
+    --schedule-accent-soft: rgba(242, 109, 155, 0.16);
+}
+
+.schedule_item[data-type="baptism"] .schedule_card {
+    --schedule-accent: #28b6a3;
+    --schedule-accent-soft: rgba(40, 182, 163, 0.16);
+}
+
+.schedule_item[data-type="devotion"] .schedule_card {
+    --schedule-accent: #8c7bff;
+    --schedule-accent-soft: rgba(140, 123, 255, 0.18);
+}
+
+.schedule_item[data-type="funeral"] .schedule_card {
+    --schedule-accent: #5c6c7d;
+    --schedule-accent-soft: rgba(92, 108, 125, 0.18);
+}
+
+.schedule_item[data-type="confirmation"] .schedule_card {
+    --schedule-accent: #ff8a4a;
+    --schedule-accent-soft: rgba(255, 138, 74, 0.18);
+}
+
+.schedule_item[data-type="outreach"] .schedule_card {
+    --schedule-accent: #2ab173;
+    --schedule-accent-soft: rgba(42, 177, 115, 0.18);
+}
+
+@media (max-width: 991px) {
+    .schedule_intro .section_title h3 {
+        font-size: 2.35rem;
+    }
+
+    .schedule_filters {
+        margin-top: -70px;
+    }
+}
+
+@media (max-width: 767px) {
+    .schedule_intro {
+        padding-top: 100px;
+        padding-bottom: 80px;
+    }
+
+    .schedule_filters .filter_buttons {
+        justify-content: flex-start;
+        overflow-x: auto;
+        padding: 24px;
+        scrollbar-width: thin;
+        scrollbar-color: rgba(60, 140, 231, 0.35) transparent;
+    }
+
+    .schedule_filters .filter_buttons::-webkit-scrollbar {
+        height: 6px;
+    }
+
+    .schedule_filters .filter_buttons::-webkit-scrollbar-thumb {
+        background: rgba(60, 140, 231, 0.35);
+        border-radius: 999px;
+    }
+
+    .schedule_filters .filter_buttons::-webkit-scrollbar-track {
+        background: transparent;
+    }
+
+    .filter_btn {
+        flex: 0 0 auto;
+    }
+
+    .schedule_card {
+        padding: 24px;
+    }
+
+    .schedule_card_header {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .schedule_card_body h4 {
+        font-size: 1.25rem;
+    }
+}
+
+@media (max-width: 575px) {
+    .schedule_intro .section_title h3 {
+        font-size: 2rem;
+    }
+
+    .schedule_filters {
+        margin-top: -60px;
+    }
+}

--- a/js/schedule.js
+++ b/js/schedule.js
@@ -2,12 +2,12 @@
     'use strict';
 
     $(document).ready(function () {
-        const buttons = $('.filter_buttons .boxed-btn3');
+        const buttons = $('.filter_buttons .filter_btn');
         const items = $('#schedule-events .schedule_item');
 
         function filterEvents(filter) {
             if (filter === 'all') {
-                items.show();
+                items.stop(true, true).fadeIn(180);
                 return;
             }
 
@@ -15,9 +15,9 @@
                 const item = $(this);
                 const type = item.data('type');
                 if (type === filter) {
-                    item.show();
+                    item.stop(true, true).fadeIn(180);
                 } else {
-                    item.hide();
+                    item.stop(true, true).fadeOut(150);
                 }
             });
         }
@@ -25,8 +25,8 @@
         buttons.on('click', function (event) {
             event.preventDefault();
             const button = $(this);
-            buttons.removeClass('active');
-            button.addClass('active');
+            buttons.removeClass('active').attr('aria-pressed', 'false');
+            button.addClass('active').attr('aria-pressed', 'true');
             filterEvents(button.data('filter'));
         });
 

--- a/schedule.php
+++ b/schedule.php
@@ -22,6 +22,7 @@
     <link rel="stylesheet" href="css/animate.css">
     <link rel="stylesheet" href="css/slicknav.css">
     <link rel="stylesheet" href="css/style.css">
+    <link rel="stylesheet" href="css/schedule.css">
 </head>
 
 <body>
@@ -96,14 +97,38 @@
     <section class="schedule_filters pb-60">
         <div class="container">
             <div class="filter_buttons text-center">
-                <button class="boxed-btn3 active" data-filter="all">All Events</button>
-                <button class="boxed-btn3" data-filter="mass">Mass</button>
-                <button class="boxed-btn3" data-filter="wedding">Weddings</button>
-                <button class="boxed-btn3" data-filter="baptism">Baptisms</button>
-                <button class="boxed-btn3" data-filter="funeral">Funeral Masses</button>
-                <button class="boxed-btn3" data-filter="confirmation">Confirmations</button>
-                <button class="boxed-btn3" data-filter="devotion">Devotions</button>
-                <button class="boxed-btn3" data-filter="outreach">Outreach</button>
+                <button type="button" class="filter_btn active" data-filter="all" aria-pressed="true">
+                    <span class="filter_icon"><i class="fa fa-calendar"></i></span>
+                    <span>All Events</span>
+                </button>
+                <button type="button" class="filter_btn" data-filter="mass" aria-pressed="false">
+                    <span class="filter_icon"><i class="fa fa-university"></i></span>
+                    <span>Mass</span>
+                </button>
+                <button type="button" class="filter_btn" data-filter="wedding" aria-pressed="false">
+                    <span class="filter_icon"><i class="fa fa-heart"></i></span>
+                    <span>Weddings</span>
+                </button>
+                <button type="button" class="filter_btn" data-filter="baptism" aria-pressed="false">
+                    <span class="filter_icon"><i class="fa fa-tint"></i></span>
+                    <span>Baptisms</span>
+                </button>
+                <button type="button" class="filter_btn" data-filter="funeral" aria-pressed="false">
+                    <span class="filter_icon"><i class="fa fa-leaf"></i></span>
+                    <span>Funeral Masses</span>
+                </button>
+                <button type="button" class="filter_btn" data-filter="confirmation" aria-pressed="false">
+                    <span class="filter_icon"><i class="fa fa-fire"></i></span>
+                    <span>Confirmations</span>
+                </button>
+                <button type="button" class="filter_btn" data-filter="devotion" aria-pressed="false">
+                    <span class="filter_icon"><i class="fa fa-moon-o"></i></span>
+                    <span>Devotions</span>
+                </button>
+                <button type="button" class="filter_btn" data-filter="outreach" aria-pressed="false">
+                    <span class="filter_icon"><i class="fa fa-users"></i></span>
+                    <span>Outreach</span>
+                </button>
             </div>
         </div>
     </section>
@@ -114,121 +139,157 @@
                 <div class="col-lg-4 col-md-6 mb-4 schedule_item" data-type="mass">
                     <div class="schedule_card h-100">
                         <div class="schedule_card_header">
-                            <span class="event_date">Sunday, Aug 4</span>
-                            <span class="event_time">8:00 AM</span>
+                            <span class="schedule_badge schedule_badge--mass"><i class="fa fa-university"></i> Mass</span>
+                            <span class="schedule_time"><i class="fa fa-clock-o"></i> 8:00 AM</span>
                         </div>
-                        <h4>18th Sunday in Ordinary Time Mass</h4>
-                        <p>Celebrant: Rev. Michael Carter<br>Music: Parish Choir</p>
+                        <div class="schedule_card_body">
+                            <span class="event_date">Sunday, Aug 4</span>
+                            <h4>18th Sunday in Ordinary Time Mass</h4>
+                            <p>Celebrant: Rev. Michael Carter<br>Music: Parish Choir</p>
+                        </div>
                     </div>
                 </div>
                 <div class="col-lg-4 col-md-6 mb-4 schedule_item" data-type="mass">
                     <div class="schedule_card h-100">
                         <div class="schedule_card_header">
-                            <span class="event_date">Sunday, Aug 4</span>
-                            <span class="event_time">10:00 AM</span>
+                            <span class="schedule_badge schedule_badge--mass"><i class="fa fa-university"></i> Mass</span>
+                            <span class="schedule_time"><i class="fa fa-clock-o"></i> 10:00 AM</span>
                         </div>
-                        <h4>Family Mass with Children’s Liturgy</h4>
-                        <p>Celebrant: Rev. Michael Carter<br>Families with young children welcome.</p>
+                        <div class="schedule_card_body">
+                            <span class="event_date">Sunday, Aug 4</span>
+                            <h4>Family Mass with Children’s Liturgy</h4>
+                            <p>Celebrant: Rev. Michael Carter<br>Families with young children welcome.</p>
+                        </div>
                     </div>
                 </div>
                 <div class="col-lg-4 col-md-6 mb-4 schedule_item" data-type="wedding">
                     <div class="schedule_card h-100">
                         <div class="schedule_card_header">
-                            <span class="event_date">Saturday, Aug 10</span>
-                            <span class="event_time">2:00 PM</span>
+                            <span class="schedule_badge schedule_badge--wedding"><i class="fa fa-heart"></i> Wedding</span>
+                            <span class="schedule_time"><i class="fa fa-clock-o"></i> 2:00 PM</span>
                         </div>
-                        <h4>Wedding: Smith &amp; Lee</h4>
-                        <p>Rehearsal scheduled for Thursday, Aug 8 at 6:30 PM.</p>
+                        <div class="schedule_card_body">
+                            <span class="event_date">Saturday, Aug 10</span>
+                            <h4>Wedding: Smith &amp; Lee</h4>
+                            <p>Rehearsal scheduled for Thursday, Aug 8 at 6:30 PM.</p>
+                        </div>
                     </div>
                 </div>
                 <div class="col-lg-4 col-md-6 mb-4 schedule_item" data-type="baptism">
                     <div class="schedule_card h-100">
                         <div class="schedule_card_header">
-                            <span class="event_date">Sunday, Aug 11</span>
-                            <span class="event_time">12:30 PM</span>
+                            <span class="schedule_badge schedule_badge--baptism"><i class="fa fa-tint"></i> Baptism</span>
+                            <span class="schedule_time"><i class="fa fa-clock-o"></i> 12:30 PM</span>
                         </div>
-                        <h4>Community Baptism Celebration</h4>
-                        <p>Families gather in the chapel following the 10:00 AM Mass.</p>
+                        <div class="schedule_card_body">
+                            <span class="event_date">Sunday, Aug 11</span>
+                            <h4>Community Baptism Celebration</h4>
+                            <p>Families gather in the chapel following the 10:00 AM Mass.</p>
+                        </div>
                     </div>
                 </div>
                 <div class="col-lg-4 col-md-6 mb-4 schedule_item" data-type="devotion">
                     <div class="schedule_card h-100">
                         <div class="schedule_card_header">
-                            <span class="event_date">Wednesday, Aug 14</span>
-                            <span class="event_time">5:30 PM</span>
+                            <span class="schedule_badge schedule_badge--devotion"><i class="fa fa-moon-o"></i> Devotion</span>
+                            <span class="schedule_time"><i class="fa fa-clock-o"></i> 5:30 PM</span>
                         </div>
-                        <h4>Adoration &amp; Confessions</h4>
-                        <p>Quiet prayer with exposition followed by the Sacrament of Reconciliation.</p>
+                        <div class="schedule_card_body">
+                            <span class="event_date">Wednesday, Aug 14</span>
+                            <h4>Adoration &amp; Confessions</h4>
+                            <p>Quiet prayer with exposition followed by the Sacrament of Reconciliation.</p>
+                        </div>
                     </div>
                 </div>
                 <div class="col-lg-4 col-md-6 mb-4 schedule_item" data-type="funeral">
                     <div class="schedule_card h-100">
                         <div class="schedule_card_header">
-                            <span class="event_date">Friday, Aug 16</span>
-                            <span class="event_time">11:00 AM</span>
+                            <span class="schedule_badge schedule_badge--funeral"><i class="fa fa-leaf"></i> Funeral</span>
+                            <span class="schedule_time"><i class="fa fa-clock-o"></i> 11:00 AM</span>
                         </div>
-                        <h4>Funeral Mass: John Johnson</h4>
-                        <p>Visitation begins at 10:00 AM with rosary at 10:30 AM.</p>
+                        <div class="schedule_card_body">
+                            <span class="event_date">Friday, Aug 16</span>
+                            <h4>Funeral Mass: John Johnson</h4>
+                            <p>Visitation begins at 10:00 AM with rosary at 10:30 AM.</p>
+                        </div>
                     </div>
                 </div>
                 <div class="col-lg-4 col-md-6 mb-4 schedule_item" data-type="confirmation">
                     <div class="schedule_card h-100">
                         <div class="schedule_card_header">
-                            <span class="event_date">Saturday, Aug 24</span>
-                            <span class="event_time">5:00 PM</span>
+                            <span class="schedule_badge schedule_badge--confirmation"><i class="fa fa-fire"></i> Confirmation</span>
+                            <span class="schedule_time"><i class="fa fa-clock-o"></i> 5:00 PM</span>
                         </div>
-                        <h4>Teen Confirmation Mass</h4>
-                        <p>Celebrated by Bishop Anthony Rivera with reception in the parish hall.</p>
+                        <div class="schedule_card_body">
+                            <span class="event_date">Saturday, Aug 24</span>
+                            <h4>Teen Confirmation Mass</h4>
+                            <p>Celebrated by Bishop Anthony Rivera with reception in the parish hall.</p>
+                        </div>
                     </div>
                 </div>
                 <div class="col-lg-4 col-md-6 mb-4 schedule_item" data-type="outreach">
                     <div class="schedule_card h-100">
                         <div class="schedule_card_header">
-                            <span class="event_date">Saturday, Aug 31</span>
-                            <span class="event_time">9:00 AM</span>
+                            <span class="schedule_badge schedule_badge--outreach"><i class="fa fa-users"></i> Outreach</span>
+                            <span class="schedule_time"><i class="fa fa-clock-o"></i> 9:00 AM</span>
                         </div>
-                        <h4>Community Pantry</h4>
-                        <p>Volunteers needed for setup at 8:00 AM. Donations welcome.</p>
+                        <div class="schedule_card_body">
+                            <span class="event_date">Saturday, Aug 31</span>
+                            <h4>Community Pantry</h4>
+                            <p>Volunteers needed for setup at 8:00 AM. Donations welcome.</p>
+                        </div>
                     </div>
                 </div>
                 <div class="col-lg-4 col-md-6 mb-4 schedule_item" data-type="wedding">
                     <div class="schedule_card h-100">
                         <div class="schedule_card_header">
-                            <span class="event_date">Saturday, Sep 7</span>
-                            <span class="event_time">11:00 AM</span>
+                            <span class="schedule_badge schedule_badge--wedding"><i class="fa fa-heart"></i> Wedding</span>
+                            <span class="schedule_time"><i class="fa fa-clock-o"></i> 11:00 AM</span>
                         </div>
-                        <h4>Wedding: Chen &amp; Rivera</h4>
-                        <p>Rehearsal scheduled for Thursday, Sep 5 at 7:00 PM.</p>
+                        <div class="schedule_card_body">
+                            <span class="event_date">Saturday, Sep 7</span>
+                            <h4>Wedding: Chen &amp; Rivera</h4>
+                            <p>Rehearsal scheduled for Thursday, Sep 5 at 7:00 PM.</p>
+                        </div>
                     </div>
                 </div>
                 <div class="col-lg-4 col-md-6 mb-4 schedule_item" data-type="baptism">
                     <div class="schedule_card h-100">
                         <div class="schedule_card_header">
-                            <span class="event_date">Sunday, Sep 8</span>
-                            <span class="event_time">1:00 PM</span>
+                            <span class="schedule_badge schedule_badge--baptism"><i class="fa fa-tint"></i> Baptism</span>
+                            <span class="schedule_time"><i class="fa fa-clock-o"></i> 1:00 PM</span>
                         </div>
-                        <h4>Adult Baptism &amp; RCIA Reception</h4>
-                        <p>Gather in the chapel following the 10:00 AM Mass for testimonies and refreshments.</p>
+                        <div class="schedule_card_body">
+                            <span class="event_date">Sunday, Sep 8</span>
+                            <h4>Adult Baptism &amp; RCIA Reception</h4>
+                            <p>Gather in the chapel following the 10:00 AM Mass for testimonies and refreshments.</p>
+                        </div>
                     </div>
                 </div>
                 <div class="col-lg-4 col-md-6 mb-4 schedule_item" data-type="devotion">
                     <div class="schedule_card h-100" id="devotions">
                         <div class="schedule_card_header">
-                            <span class="event_date">Wednesday, Sep 11</span>
-                            <span class="event_time">6:00 PM</span>
+                            <span class="schedule_badge schedule_badge--devotion"><i class="fa fa-moon-o"></i> Devotion</span>
+                            <span class="schedule_time"><i class="fa fa-clock-o"></i> 6:00 PM</span>
                         </div>
-                        <h4>Taizé Prayer Service</h4>
-                        <p>Experience meditative music, Scripture, and candlelight prayer in the sanctuary.</p>
+                        <div class="schedule_card_body">
+                            <span class="event_date">Wednesday, Sep 11</span>
+                            <h4>Taizé Prayer Service</h4>
+                            <p>Experience meditative music, Scripture, and candlelight prayer in the sanctuary.</p>
+                        </div>
                     </div>
                 </div>
                 <div class="col-lg-4 col-md-6 mb-4 schedule_item" data-type="funeral">
                     <div class="schedule_card h-100">
                         <div class="schedule_card_header">
-                            <span class="event_date">Thursday, Sep 12</span>
-                            <span class="event_time">10:30 AM</span>
+                            <span class="schedule_badge schedule_badge--funeral"><i class="fa fa-leaf"></i> Funeral</span>
+                            <span class="schedule_time"><i class="fa fa-clock-o"></i> 10:30 AM</span>
                         </div>
-                        <h4>Memorial Mass: Maria Gomez</h4>
-                        <p>Family rosary at 10:00 AM. Reception in the parish hall following Mass.</p>
+                        <div class="schedule_card_body">
+                            <span class="event_date">Thursday, Sep 12</span>
+                            <h4>Memorial Mass: Maria Gomez</h4>
+                            <p>Family rosary at 10:00 AM. Reception in the parish hall following Mass.</p>
+                        </div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- add schedule-specific stylesheet with refreshed hero, filter, and card styling
- restyle schedule cards with icons, badges, and improved typography for each event type
- improve filter controls and animations for a more accessible browsing experience

## Testing
- php -l schedule.php

------
https://chatgpt.com/codex/tasks/task_e_68e4c8a9ebdc8332ba77eddcbb0125a4