### PR TITLE
Restyle homepage highlights section

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -164,6 +164,126 @@
     box-shadow: 0 25px 45px rgba(15, 61, 145, 0.12);
 }
 
+.highlight_card {
+    position: relative;
+    padding: 0;
+    border-radius: 20px;
+    overflow: hidden;
+    background: linear-gradient(180deg, #ffffff 0%, #f7f9ff 100%);
+    box-shadow: 0 25px 45px rgba(15, 61, 145, 0.12);
+    border-top: none;
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.highlight_card::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 6px;
+    background: linear-gradient(90deg, #4ac4a4 0%, #6e8efb 100%);
+    z-index: 2;
+}
+
+.highlight_card .room_thumb {
+    margin: 0;
+}
+
+.highlight_card .highlight_media {
+    position: relative;
+    overflow: hidden;
+}
+
+.highlight_card .highlight_media img {
+    width: 100%;
+    height: 220px;
+    object-fit: cover;
+    display: block;
+    transition: transform 0.4s ease;
+}
+
+.highlight_card:hover .highlight_media img {
+    transform: scale(1.05);
+}
+
+.highlight_badge {
+    position: absolute;
+    top: 20px;
+    left: 20px;
+    background: rgba(255, 255, 255, 0.92);
+    color: #205072;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-size: 11px;
+    padding: 6px 14px;
+    border-radius: 999px;
+    box-shadow: 0 12px 26px rgba(15, 61, 145, 0.18);
+    z-index: 3;
+}
+
+.highlight_card .room_heading {
+    padding: 28px 30px 32px;
+    border: 0;
+    background: transparent;
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+}
+
+.highlight_meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px 18px;
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-weight: 600;
+    color: #7183a6;
+}
+
+.highlight_meta span {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.highlight_meta i {
+    color: #4ac4a4;
+}
+
+.highlight_card h3 {
+    font-size: 24px;
+    margin: 0;
+    color: #132d55;
+}
+
+.highlight_time {
+    margin: 0;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: #1f7a6d;
+}
+
+.highlight_description {
+    margin: 0;
+    color: #525a75;
+    line-height: 1.6;
+}
+
+.highlight_card .line-button {
+    align-self: flex-start;
+    font-weight: 600;
+    color: #132d55;
+}
+
+.highlight_card:hover {
+    transform: translateY(-10px);
+    box-shadow: 0 35px 70px rgba(15, 61, 145, 0.18);
+}
+
 .schedule_card_header {
     display: flex;
     justify-content: space-between;
@@ -297,5 +417,31 @@
     .testimonial_card,
     .cta_box {
         padding: 24px;
+    }
+
+    .highlight_card .room_heading {
+        padding: 24px 24px 28px;
+    }
+
+    .highlight_card .highlight_media img {
+        height: 200px;
+    }
+}
+
+@media (max-width: 575px) {
+    .highlight_card {
+        border-radius: 16px;
+    }
+
+    .highlight_card .highlight_media img {
+        height: 180px;
+    }
+
+    .highlight_card h3 {
+        font-size: 22px;
+    }
+
+    .highlight_meta {
+        font-size: 11px;
     }
 }

--- a/index.php
+++ b/index.php
@@ -224,38 +224,56 @@
             </div>
             <div class="row">
                 <div class="col-xl-4 col-md-6">
-                    <div class="single_rooms schedule_card">
-                        <div class="room_thumb">
-                            <img src="img/rooms/1.png" alt="Sunday Mass" class="rounded">
+                    <div class="single_rooms schedule_card highlight_card">
+                        <div class="room_thumb highlight_media">
+                            <img src="img/rooms/1.png" alt="Sunday Mass">
+                            <span class="highlight_badge">Worship</span>
                         </div>
-                        <div class="room_heading">
+                        <div class="room_heading highlight_body">
+                            <div class="highlight_meta">
+                                <span><i class="fa fa-calendar"></i> Sundays</span>
+                                <span><i class="fa fa-map-marker"></i> Main Church</span>
+                            </div>
                             <h3>Sunday Masses</h3>
-                            <p>8:00 AM, 10:00 AM, and 6:00 PM</p>
-                            <a class="line-button" href="schedule.php">See full schedule</a>
+                            <p class="highlight_time">8:00 AM · 10:00 AM · 6:00 PM</p>
+                            <p class="highlight_description">Celebrate the Eucharist with the parish community throughout the day.</p>
+                            <a class="line-button highlight_link" href="schedule.php">See full schedule</a>
                         </div>
                     </div>
                 </div>
                 <div class="col-xl-4 col-md-6">
-                    <div class="single_rooms schedule_card">
-                        <div class="room_thumb">
-                            <img src="img/rooms/2.png" alt="Eucharistic adoration" class="rounded">
+                    <div class="single_rooms schedule_card highlight_card">
+                        <div class="room_thumb highlight_media">
+                            <img src="img/rooms/2.png" alt="Eucharistic adoration">
+                            <span class="highlight_badge">Prayer</span>
                         </div>
-                        <div class="room_heading">
+                        <div class="room_heading highlight_body">
+                            <div class="highlight_meta">
+                                <span><i class="fa fa-calendar"></i> Wednesdays</span>
+                                <span><i class="fa fa-map-marker"></i> Adoration Chapel</span>
+                            </div>
                             <h3>Adoration &amp; Reconciliation</h3>
-                            <p>Wednesdays at 5:30 PM in the chapel</p>
-                            <a class="line-button" href="schedule.php#devotions">Learn more</a>
+                            <p class="highlight_time">5:30 PM – Holy Hour &amp; Confessions</p>
+                            <p class="highlight_description">Rest in silent prayer before the Blessed Sacrament and receive the sacrament of reconciliation.</p>
+                            <a class="line-button highlight_link" href="schedule.php#devotions">Learn more</a>
                         </div>
                     </div>
                 </div>
                 <div class="col-xl-4 col-md-6">
-                    <div class="single_rooms schedule_card">
-                        <div class="room_thumb">
-                            <img src="img/rooms/3.png" alt="Community outreach" class="rounded">
+                    <div class="single_rooms schedule_card highlight_card">
+                        <div class="room_thumb highlight_media">
+                            <img src="img/rooms/3.png" alt="Community outreach">
+                            <span class="highlight_badge">Outreach</span>
                         </div>
-                        <div class="room_heading">
+                        <div class="room_heading highlight_body">
+                            <div class="highlight_meta">
+                                <span><i class="fa fa-calendar"></i> Saturdays</span>
+                                <span><i class="fa fa-map-marker"></i> Parish Hall</span>
+                            </div>
                             <h3>Community Pantry</h3>
-                            <p>Saturdays from 9:00 AM – 11:00 AM</p>
-                            <a class="line-button" href="services.php#outreach">Support the mission</a>
+                            <p class="highlight_time">9:00 AM – 11:00 AM</p>
+                            <p class="highlight_description">Serve neighbors with fresh groceries, warm smiles, and a welcoming community meal.</p>
+                            <a class="line-button highlight_link" href="services.php#outreach">Support the mission</a>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- redesign the homepage highlights cards with badges, meta details, and updated copy
- add dedicated highlight card styling for imagery, typography, and hover states including responsive tweaks

## Testing
- Manual - Viewed index.php in browser

------
https://chatgpt.com/codex/tasks/task_e_68e4ccbc659c833285941d46293b2e7f