### PR TITLE
Refine reservation calendar statuses

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -83,6 +83,7 @@
 .availability_calendar {
     display: grid;
     gap: 24px;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
 }
 
 .calendar_month_header {
@@ -102,6 +103,7 @@
     width: 100%;
     border-collapse: separate;
     border-spacing: 8px;
+    table-layout: fixed;
 }
 
 .calendar_table th {
@@ -124,6 +126,8 @@
     border: 1px solid #ece9ff;
     display: flex;
     flex-direction: column;
+    align-items: flex-start;
+    height: 100%;
 }
 
 .calendar_day .day_number {
@@ -134,9 +138,14 @@
 
 .calendar_day .day_label {
     margin-top: auto;
-    font-size: 12px;
-    line-height: 1.4;
-    color: #5c5c5c;
+    align-self: center;
+    font-size: 11px;
+    line-height: 1;
+    font-weight: 600;
+    letter-spacing: 0.6px;
+    padding: 6px 10px 5px;
+    border-radius: 999px;
+    text-transform: uppercase;
 }
 
 .calendar_day.status_booked {
@@ -152,6 +161,16 @@
 .calendar_day.status_available {
     background: #eefaf4;
     border-color: #cceadf;
+}
+
+.calendar_day.status_booked .day_label {
+    background: #ff6363;
+    color: #ffffff;
+}
+
+.calendar_day.status_pending .day_label {
+    background: #ffbe3d;
+    color: #4a3500;
 }
 
 .schedule_card {

--- a/js/reservations.js
+++ b/js/reservations.js
@@ -22,25 +22,36 @@
             available: 'available'
         };
 
+        const statusLabels = {
+            [statuses.booked]: 'Booked',
+            [statuses.pending]: 'Pending',
+            [statuses.available]: 'Available'
+        };
+
         const today = new Date();
+        today.setHours(0, 0, 0, 0);
+
         const baseYear = today.getFullYear();
         const baseMonth = today.getMonth();
 
-        function toISO(year, month, day) {
-            const date = new Date(year, month, day);
-            return date.toISOString().split('T')[0];
+        function toLocalKey(year, month, day) {
+            const paddedMonth = String(month + 1).padStart(2, '0');
+            const paddedDay = String(day).padStart(2, '0');
+            return `${year}-${paddedMonth}-${paddedDay}`;
         }
 
         const sampleBookings = {};
-        sampleBookings[toISO(baseYear, baseMonth, 5)] = { status: statuses.booked, label: 'Wedding - Smith &amp; Lee' };
-        sampleBookings[toISO(baseYear, baseMonth, 12)] = { status: statuses.pending, label: 'Baptism - Garcia Family' };
-        sampleBookings[toISO(baseYear, baseMonth, 18)] = { status: statuses.booked, label: 'Funeral Mass - Johnson' };
-        sampleBookings[toISO(baseYear, baseMonth, 24)] = { status: statuses.available, label: 'Available for morning' };
+        sampleBookings[toLocalKey(baseYear, baseMonth, 5)] = { status: statuses.booked };
+        sampleBookings[toLocalKey(baseYear, baseMonth, 12)] = { status: statuses.pending };
+        sampleBookings[toLocalKey(baseYear, baseMonth, 18)] = { status: statuses.booked };
+        sampleBookings[toLocalKey(baseYear, baseMonth, 24)] = { status: statuses.available };
 
         const nextMonthDate = new Date(baseYear, baseMonth + 1, 1);
-        sampleBookings[toISO(nextMonthDate.getFullYear(), nextMonthDate.getMonth(), 2)] = { status: statuses.booked, label: 'Confirmation Mass' };
-        sampleBookings[toISO(nextMonthDate.getFullYear(), nextMonthDate.getMonth(), 15)] = { status: statuses.pending, label: 'Wedding - Chen &amp; Rivera' };
-        sampleBookings[toISO(nextMonthDate.getFullYear(), nextMonthDate.getMonth(), 28)] = { status: statuses.booked, label: 'Quinceañera - Martinez' };
+        const nextYear = nextMonthDate.getFullYear();
+        const nextMonth = nextMonthDate.getMonth();
+        sampleBookings[toLocalKey(nextYear, nextMonth, 2)] = { status: statuses.booked };
+        sampleBookings[toLocalKey(nextYear, nextMonth, 15)] = { status: statuses.pending };
+        sampleBookings[toLocalKey(nextYear, nextMonth, 28)] = { status: statuses.booked };
 
         const monthNames = [
             'January', 'February', 'March', 'April', 'May', 'June',
@@ -86,7 +97,7 @@
 
             for (let day = 1; day <= lastDay.getDate(); day += 1) {
                 const date = new Date(year, month, day);
-                const isoDate = date.toISOString().split('T')[0];
+                const isoDate = toLocalKey(date.getFullYear(), date.getMonth(), day);
                 const booking = sampleBookings[isoDate];
 
                 const cell = document.createElement('td');
@@ -95,11 +106,15 @@
                 cellWrapper.innerHTML = `<span class="day_number">${day}</span>`;
 
                 if (booking) {
-                    cellWrapper.classList.add(`status_${booking.status}`);
-                    const label = document.createElement('small');
-                    label.className = 'day_label';
-                    label.innerHTML = booking.label;
-                    cellWrapper.appendChild(label);
+                    const status = booking.status || statuses.available;
+                    cellWrapper.classList.add(`status_${status}`);
+
+                    if (status !== statuses.available) {
+                        const label = document.createElement('small');
+                        label.className = 'day_label';
+                        label.textContent = statusLabels[status] || '';
+                        cellWrapper.appendChild(label);
+                    }
                 } else {
                     cellWrapper.classList.add('status_available');
                 }

--- a/reservation.php
+++ b/reservation.php
@@ -96,7 +96,19 @@
     <section class="reservation_form_area pb-120">
         <div class="container">
             <div class="row">
-                <div class="col-lg-6">
+                <div class="col-12">
+                    <div class="reservation_calendar mb-5">
+                        <h4 class="mb-4">Availability Preview</h4>
+                        <p class="mb-4">The calendar below shows the current status of select dates. Dates marked as <span class="badge badge-success">Available</span> are open for reservations. Dates marked as <span class="badge badge-danger">Booked</span> already have scheduled events.</p>
+                        <div class="calendar_legend mb-3">
+                            <span><span class="legend available"></span> Available</span>
+                            <span><span class="legend pending"></span> Pending</span>
+                            <span><span class="legend booked"></span> Booked</span>
+                        </div>
+                        <div class="availability_calendar" id="availability-calendar"></div>
+                    </div>
+                </div>
+                <div class="col-12 col-xl-10 mx-auto">
                     <form id="reservation-form" class="reservation_form">
                         <h4 class="mb-4">Reservation Details</h4>
                         <div class="form-group">
@@ -142,18 +154,6 @@
                             Thank you! Your reservation request has been received. We will contact you soon to confirm the details.
                         </div>
                     </form>
-                </div>
-                <div class="col-lg-6">
-                    <div class="reservation_calendar">
-                        <h4 class="mb-4">Availability Preview</h4>
-                        <p class="mb-4">The calendar below shows the current status of select dates. Dates marked as <span class="badge badge-success">Available</span> are open for reservations. Dates marked as <span class="badge badge-danger">Booked</span> already have scheduled events.</p>
-                        <div class="calendar_legend mb-3">
-                            <span><span class="legend available"></span> Available</span>
-                            <span><span class="legend pending"></span> Pending</span>
-                            <span><span class="legend booked"></span> Booked</span>
-                        </div>
-                        <div class="availability_calendar" id="availability-calendar"></div>
-                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- restructure the reservation page so the availability calendar spans the full width ahead of the reservation form
- update calendar grid styling so month cards expand responsively and each day cell keeps a consistent width
- ensure booked days display a concise “Booked” label with updated styling so the chip fits comfortably within each day cell
- generate the availability sample data using local current and next month keys to keep the calendar aligned with the visitor’s locale

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5e96f72f88332bf2feda700058e55