### PR TITLE
Improve reservation calendar layout

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -46,19 +46,22 @@
 }
 
 .calendar_legend {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 20px;
+    display: inline-flex;
+    align-items: center;
+    gap: 16px;
     font-weight: 600;
     text-transform: uppercase;
     font-size: 12px;
     letter-spacing: 1px;
+    padding: 10px 18px;
+    border-radius: 999px;
+    background: rgba(74, 196, 164, 0.12);
 }
 
 .calendar_legend span {
-    display: flex;
+    display: inline-flex;
     align-items: center;
-    gap: 8px;
+    gap: 10px;
 }
 
 .calendar_legend .legend {
@@ -66,43 +69,57 @@
     height: 16px;
     border-radius: 50%;
     display: inline-block;
-}
-
-.calendar_legend .legend.available {
-    background: #4ac4a4;
-}
-
-.calendar_legend .legend.pending {
-    background: #ffbe3d;
-}
-
-.calendar_legend .legend.booked {
-    background: #ff6363;
+    background: #ff6b6b;
+    box-shadow: 0 0 0 4px rgba(255, 107, 107, 0.12);
 }
 
 .availability_calendar {
     display: grid;
-    gap: 24px;
-    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 32px;
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    align-items: stretch;
+}
+
+.calendar_month {
+    background: #ffffff;
+    border-radius: 24px;
+    padding: 28px;
+    box-shadow: 0 25px 45px rgba(15, 61, 145, 0.1);
+    border: 1px solid rgba(58, 43, 140, 0.08);
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
 }
 
 .calendar_month_header {
     display: flex;
     align-items: center;
-    justify-content: center;
-    margin-bottom: 20px;
+    justify-content: space-between;
+    gap: 12px;
+}
+
+.calendar_month_header::after,
+.calendar_month_header::before {
+    content: "";
+    flex: 1;
+    height: 1px;
+    background: linear-gradient(90deg, rgba(74, 196, 164, 0), rgba(74, 196, 164, 0.35), rgba(74, 196, 164, 0));
 }
 
 .calendar_month_header h5 {
     margin: 0;
     font-weight: 700;
-    letter-spacing: 1px;
+    letter-spacing: 1.2px;
+    font-size: 18px;
+    color: #3a2b8c;
+    text-transform: uppercase;
+    white-space: nowrap;
 }
 
 .calendar_table {
     width: 100%;
     border-collapse: separate;
-    border-spacing: 8px;
+    border-spacing: 12px;
     table-layout: fixed;
 }
 
@@ -110,30 +127,46 @@
     text-align: center;
     text-transform: uppercase;
     font-size: 12px;
-    color: #777777;
+    color: #8b86aa;
+    letter-spacing: 1px;
 }
 
 .calendar_table td {
     padding: 0;
+    vertical-align: top;
 }
 
 .calendar_day {
-    min-height: 90px;
-    background: #f7f7fb;
-    border-radius: 8px;
-    padding: 8px 10px;
-    position: relative;
-    border: 1px solid #ece9ff;
+    min-height: 110px;
+    background: linear-gradient(180deg, #f8f9ff 0%, #f2f6ff 100%);
+    border-radius: 16px;
+    padding: 12px 14px;
+    border: 1px solid rgba(58, 43, 140, 0.12);
     display: flex;
     flex-direction: column;
+    justify-content: space-between;
     align-items: flex-start;
+    transition: box-shadow 0.3s ease, transform 0.3s ease;
     height: 100%;
+}
+
+.calendar_day:hover {
+    transform: translateY(-3px);
+    box-shadow: 0 16px 35px rgba(15, 61, 145, 0.16);
+}
+
+.calendar_day.is_empty {
+    background: transparent;
+    border-color: transparent;
+    box-shadow: none;
+    pointer-events: none;
 }
 
 .calendar_day .day_number {
     font-weight: 700;
-    font-size: 16px;
-    color: #3a2b8c;
+    font-size: 18px;
+    color: #2b1b6b;
+    letter-spacing: 0.5px;
 }
 
 .calendar_day .day_label {
@@ -141,36 +174,29 @@
     align-self: center;
     font-size: 11px;
     line-height: 1;
-    font-weight: 600;
-    letter-spacing: 0.6px;
-    padding: 6px 10px 5px;
+    font-weight: 700;
+    letter-spacing: 1px;
+    padding: 7px 12px 6px;
     border-radius: 999px;
     text-transform: uppercase;
-}
-
-.calendar_day.status_booked {
-    background: #ffeaea;
-    border-color: #ffb4b4;
-}
-
-.calendar_day.status_pending {
-    background: #fff5dd;
-    border-color: #ffd395;
+    background: rgba(74, 196, 164, 0.18);
+    color: #208162;
 }
 
 .calendar_day.status_available {
-    background: #eefaf4;
-    border-color: #cceadf;
+    background: linear-gradient(180deg, #f4fffb 0%, #ebfff6 100%);
+    border-color: rgba(64, 171, 140, 0.28);
+}
+
+.calendar_day.status_booked {
+    background: linear-gradient(180deg, #fff3f3 0%, #ffe7e7 100%);
+    border-color: rgba(255, 107, 107, 0.4);
 }
 
 .calendar_day.status_booked .day_label {
-    background: #ff6363;
+    background: rgba(255, 107, 107, 0.85);
     color: #ffffff;
-}
-
-.calendar_day.status_pending .day_label {
-    background: #ffbe3d;
-    color: #4a3500;
+    box-shadow: 0 10px 20px rgba(255, 107, 107, 0.25);
 }
 
 .schedule_card {

--- a/js/reservations.js
+++ b/js/reservations.js
@@ -18,14 +18,11 @@
     function buildCalendar(container, monthsToRender) {
         const statuses = {
             booked: 'booked',
-            pending: 'pending',
             available: 'available'
         };
 
         const statusLabels = {
-            [statuses.booked]: 'Booked',
-            [statuses.pending]: 'Pending',
-            [statuses.available]: 'Available'
+            [statuses.booked]: 'Booked'
         };
 
         const today = new Date();
@@ -41,17 +38,18 @@
         }
 
         const sampleBookings = {};
-        sampleBookings[toLocalKey(baseYear, baseMonth, 5)] = { status: statuses.booked };
-        sampleBookings[toLocalKey(baseYear, baseMonth, 12)] = { status: statuses.pending };
+        sampleBookings[toLocalKey(baseYear, baseMonth, 4)] = { status: statuses.booked };
+        sampleBookings[toLocalKey(baseYear, baseMonth, 11)] = { status: statuses.booked };
         sampleBookings[toLocalKey(baseYear, baseMonth, 18)] = { status: statuses.booked };
-        sampleBookings[toLocalKey(baseYear, baseMonth, 24)] = { status: statuses.available };
+        sampleBookings[toLocalKey(baseYear, baseMonth, 23)] = { status: statuses.booked };
 
         const nextMonthDate = new Date(baseYear, baseMonth + 1, 1);
         const nextYear = nextMonthDate.getFullYear();
         const nextMonth = nextMonthDate.getMonth();
-        sampleBookings[toLocalKey(nextYear, nextMonth, 2)] = { status: statuses.booked };
-        sampleBookings[toLocalKey(nextYear, nextMonth, 15)] = { status: statuses.pending };
-        sampleBookings[toLocalKey(nextYear, nextMonth, 28)] = { status: statuses.booked };
+        sampleBookings[toLocalKey(nextYear, nextMonth, 6)] = { status: statuses.booked };
+        sampleBookings[toLocalKey(nextYear, nextMonth, 12)] = { status: statuses.booked };
+        sampleBookings[toLocalKey(nextYear, nextMonth, 21)] = { status: statuses.booked };
+        sampleBookings[toLocalKey(nextYear, nextMonth, 27)] = { status: statuses.booked };
 
         const monthNames = [
             'January', 'February', 'March', 'April', 'May', 'June',
@@ -59,6 +57,14 @@
         ];
 
         const weekdayNames = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+
+        function appendEmptyCell(row) {
+            const emptyCell = document.createElement('td');
+            const emptyWrapper = document.createElement('div');
+            emptyWrapper.className = 'calendar_day is_empty';
+            emptyCell.appendChild(emptyWrapper);
+            row.appendChild(emptyCell);
+        }
 
         function renderMonth(baseDate) {
             const year = baseDate.getFullYear();
@@ -92,7 +98,7 @@
             let currentRow = document.createElement('tr');
 
             for (let i = 0; i < firstDay.getDay(); i += 1) {
-                currentRow.appendChild(document.createElement('td'));
+                appendEmptyCell(currentRow);
             }
 
             for (let day = 1; day <= lastDay.getDate(); day += 1) {
@@ -102,21 +108,25 @@
 
                 const cell = document.createElement('td');
                 const cellWrapper = document.createElement('div');
+                const dayNumber = document.createElement('span');
+                dayNumber.className = 'day_number';
+                dayNumber.textContent = day;
+
                 cellWrapper.className = 'calendar_day';
-                cellWrapper.innerHTML = `<span class="day_number">${day}</span>`;
+                cellWrapper.appendChild(dayNumber);
 
-                if (booking) {
-                    const status = booking.status || statuses.available;
-                    cellWrapper.classList.add(`status_${status}`);
+                let status = statuses.available;
+                if (booking && booking.status === statuses.booked) {
+                    status = statuses.booked;
+                }
 
-                    if (status !== statuses.available) {
-                        const label = document.createElement('small');
-                        label.className = 'day_label';
-                        label.textContent = statusLabels[status] || '';
-                        cellWrapper.appendChild(label);
-                    }
-                } else {
-                    cellWrapper.classList.add('status_available');
+                cellWrapper.classList.add(`status_${status}`);
+
+                if (status === statuses.booked) {
+                    const label = document.createElement('small');
+                    label.className = 'day_label';
+                    label.textContent = statusLabels[status];
+                    cellWrapper.appendChild(label);
                 }
 
                 cell.appendChild(cellWrapper);
@@ -130,7 +140,7 @@
 
             if (currentRow.children.length) {
                 while (currentRow.children.length < 7) {
-                    currentRow.appendChild(document.createElement('td'));
+                    appendEmptyCell(currentRow);
                 }
                 tbody.appendChild(currentRow);
             }

--- a/reservation.php
+++ b/reservation.php
@@ -99,10 +99,8 @@
                 <div class="col-12">
                     <div class="reservation_calendar mb-5">
                         <h4 class="mb-4">Availability Preview</h4>
-                        <p class="mb-4">The calendar below shows the current status of select dates. Dates marked as <span class="badge badge-success">Available</span> are open for reservations. Dates marked as <span class="badge badge-danger">Booked</span> already have scheduled events.</p>
+                        <p class="mb-4">The calendar below highlights dates that are no longer available. Look for the <span class="badge badge-danger">Booked</span> tag—days without a tag remain open for new reservations.</p>
                         <div class="calendar_legend mb-3">
-                            <span><span class="legend available"></span> Available</span>
-                            <span><span class="legend pending"></span> Pending</span>
                             <span><span class="legend booked"></span> Booked</span>
                         </div>
                         <div class="availability_calendar" id="availability-calendar"></div>


### PR DESCRIPTION
## Summary
- refresh the availability calendar styling to display two months side-by-side with evenly sized day tiles
- simplify the status display so only booked days are labeled and update the legend copy accordingly

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e5f34fa0dc83329b492e5e023a1a21