### PR TITLE
Align nav menus across pages

### DIFF
--- a/about.php
+++ b/about.php
@@ -36,10 +36,7 @@
                                     <ul id="navigation">
                                         <li><a href="index.php">Home</a></li>
                                         <li><a class="active" href="about.php">About</a></li>
-                                        <li><a href="reservation.php">Reservations</a></li>
                                         <li><a href="schedule.php">Schedule</a></li>
-                                        <li><a href="services.php">Services</a></li>
-                                        <li><a href="gallery.php">Gallery</a></li>
                                         <li><a href="contact.php">Contact</a></li>
                                     </ul>
                                 </nav>

--- a/blog.php
+++ b/blog.php
@@ -42,20 +42,9 @@
                             <div class="main-menu  d-none d-lg-block">
                                 <nav>
                                     <ul id="navigation">
-                                        <li><a href="index.php">home</a></li>
-                                        <li><a href="rooms.php">rooms</a></li>
+                                        <li><a href="index.php">Home</a></li>
                                         <li><a href="about.php">About</a></li>
-                                        <li><a class="active" href="#">blog <i class="ti-angle-down"></i></a>
-                                            <ul class="submenu">
-                                                <li><a href="blog.php">blog</a></li>
-                                                <li><a href="single-blog.php">single-blog</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">pages <i class="ti-angle-down"></i></a>
-                                            <ul class="submenu">
-                                                <li><a href="elements.php">elements</a></li>
-                                            </ul>
-                                        </li>
+                                        <li><a href="schedule.php">Schedule</a></li>
                                         <li><a href="contact.php">Contact</a></li>
                                     </ul>
                                 </nav>

--- a/contact.php
+++ b/contact.php
@@ -36,10 +36,7 @@
                                     <ul id="navigation">
                                         <li><a href="index.php">Home</a></li>
                                         <li><a href="about.php">About</a></li>
-                                        <li><a href="reservation.php">Reservations</a></li>
                                         <li><a href="schedule.php">Schedule</a></li>
-                                        <li><a href="services.php">Services</a></li>
-                                        <li><a href="gallery.php">Gallery</a></li>
                                         <li><a class="active" href="contact.php">Contact</a></li>
                                     </ul>
                                 </nav>

--- a/elements.php
+++ b/elements.php
@@ -42,20 +42,9 @@
                             <div class="main-menu  d-none d-lg-block">
                                 <nav>
                                     <ul id="navigation">
-                                        <li><a href="index.php">home</a></li>
-                                        <li><a href="rooms.php">rooms</a></li>
+                                        <li><a href="index.php">Home</a></li>
                                         <li><a href="about.php">About</a></li>
-                                        <li><a href="#">blog <i class="ti-angle-down"></i></a>
-                                            <ul class="submenu">
-                                                <li><a href="blog.php">blog</a></li>
-                                                <li><a href="single-blog.php">single-blog</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a class="active" href="#">pages <i class="ti-angle-down"></i></a>
-                                            <ul class="submenu">
-                                                <li><a href="elements.php">elements</a></li>
-                                            </ul>
-                                        </li>
+                                        <li><a href="schedule.php">Schedule</a></li>
                                         <li><a href="contact.php">Contact</a></li>
                                     </ul>
                                 </nav>

--- a/gallery.php
+++ b/gallery.php
@@ -36,10 +36,7 @@
                                     <ul id="navigation">
                                         <li><a href="index.php">Home</a></li>
                                         <li><a href="about.php">About</a></li>
-                                        <li><a href="reservation.php">Reservations</a></li>
                                         <li><a href="schedule.php">Schedule</a></li>
-                                        <li><a href="services.php">Services</a></li>
-                                        <li><a class="active" href="gallery.php">Gallery</a></li>
                                         <li><a href="contact.php">Contact</a></li>
                                     </ul>
                                 </nav>

--- a/reservation.php
+++ b/reservation.php
@@ -36,10 +36,7 @@
                                     <ul id="navigation">
                                         <li><a href="index.php">Home</a></li>
                                         <li><a href="about.php">About</a></li>
-                                        <li><a class="active" href="reservation.php">Reservations</a></li>
                                         <li><a href="schedule.php">Schedule</a></li>
-                                        <li><a href="services.php">Services</a></li>
-                                        <li><a href="gallery.php">Gallery</a></li>
                                         <li><a href="contact.php">Contact</a></li>
                                     </ul>
                                 </nav>

--- a/rooms.php
+++ b/rooms.php
@@ -42,20 +42,9 @@
                             <div class="main-menu  d-none d-lg-block">
                                 <nav>
                                     <ul id="navigation">
-                                        <li><a href="index.php">home</a></li>
-                                        <li><a class="active" href="rooms.php">rooms</a></li>
+                                        <li><a href="index.php">Home</a></li>
                                         <li><a href="about.php">About</a></li>
-                                        <li><a href="#">blog <i class="ti-angle-down"></i></a>
-                                            <ul class="submenu">
-                                                <li><a href="blog.php">blog</a></li>
-                                                <li><a href="single-blog.php">single-blog</a></li>
-                                            </ul>
-                                        </li>
-                                        <li><a href="#">pages <i class="ti-angle-down"></i></a>
-                                            <ul class="submenu">
-                                                <li><a href="elements.php">elements</a></li>
-                                            </ul>
-                                        </li>
+                                        <li><a href="schedule.php">Schedule</a></li>
                                         <li><a href="contact.php">Contact</a></li>
                                     </ul>
                                 </nav>

--- a/schedule.php
+++ b/schedule.php
@@ -37,10 +37,7 @@
                                     <ul id="navigation">
                                         <li><a href="index.php">Home</a></li>
                                         <li><a href="about.php">About</a></li>
-                                        <li><a href="reservation.php">Reservations</a></li>
                                         <li><a class="active" href="schedule.php">Schedule</a></li>
-                                        <li><a href="services.php">Services</a></li>
-                                        <li><a href="gallery.php">Gallery</a></li>
                                         <li><a href="contact.php">Contact</a></li>
                                     </ul>
                                 </nav>

--- a/services.php
+++ b/services.php
@@ -36,10 +36,7 @@
                                     <ul id="navigation">
                                         <li><a href="index.php">Home</a></li>
                                         <li><a href="about.php">About</a></li>
-                                        <li><a href="reservation.php">Reservations</a></li>
                                         <li><a href="schedule.php">Schedule</a></li>
-                                        <li><a class="active" href="services.php">Services</a></li>
-                                        <li><a href="gallery.php">Gallery</a></li>
                                         <li><a href="contact.php">Contact</a></li>
                                     </ul>
                                 </nav>

--- a/single-blog.php
+++ b/single-blog.php
@@ -42,20 +42,9 @@
                           <div class="main-menu  d-none d-lg-block">
                               <nav>
                                   <ul id="navigation">
-                                      <li><a href="index.php">home</a></li>
-                                      <li><a href="rooms.php">rooms</a></li>
+                                      <li><a href="index.php">Home</a></li>
                                       <li><a href="about.php">About</a></li>
-                                      <li><a class="active" href="#">blog <i class="ti-angle-down"></i></a>
-                                          <ul class="submenu">
-                                              <li><a href="blog.php">blog</a></li>
-                                              <li><a href="single-blog.php">single-blog</a></li>
-                                          </ul>
-                                      </li>
-                                      <li><a href="#">pages <i class="ti-angle-down"></i></a>
-                                          <ul class="submenu">
-                                              <li><a href="elements.php">elements</a></li>
-                                          </ul>
-                                      </li>
+                                      <li><a href="schedule.php">Schedule</a></li>
                                       <li><a href="contact.php">Contact</a></li>
                                   </ul>
                               </nav>


### PR DESCRIPTION
## Summary
- replace each page header navigation with the four core links used on the home page
- retain page-specific active states only for Home, About, Schedule, and Contact

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5fe2332888332a11b0157ced537f0