### PR TITLE
Fix reservation date persistence and calendar data loading

### DIFF
--- a/database/reservations.sql
+++ b/database/reservations.sql
@@ -13,8 +13,9 @@ CREATE TABLE IF NOT EXISTS `reservations` (
   `email` VARCHAR(255) NOT NULL,
   `phone` VARCHAR(50) NOT NULL,
   `event_type` VARCHAR(100) NOT NULL,
-  `preferred_date` VARCHAR(50) NOT NULL,
+  `preferred_date` DATE NOT NULL,
   `preferred_time` VARCHAR(50) NOT NULL,
+  `status` ENUM('pending','approved','declined') NOT NULL DEFAULT 'pending',
   `notes` TEXT,
   `created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`)


### PR DESCRIPTION
## Summary
- normalize and validate reservation dates before saving so MySQL DATE columns store the correct value
- expose approved reservation dates for the availability calendar with graceful fallbacks when status filtering is unavailable
- update the database schema to use a DATE column for preferred_date and include a reservation status field

## Testing
- php -l reservation.php

------
https://chatgpt.com/codex/tasks/task_e_68e6309168f48332a5aa175b0aef2abd