### PR TITLE
Improve reservation banner readability

### DIFF
--- a/css/reservation-overrides.css
+++ b/css/reservation-overrides.css
@@ -44,3 +44,24 @@ body.reservation-page .gj-picker.gj-picker-bootstrap {
 body.reservation-page .gj-picker.gj-picker-bootstrap [role="body"] {
     font-size: 1rem;
 }
+
+body.reservation-page .bradcam_area {
+    position: relative;
+    overflow: hidden;
+}
+
+body.reservation-page .bradcam_area::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    background: rgba(0, 0, 0, 0.45);
+    z-index: 0;
+}
+
+body.reservation-page .bradcam_area > * {
+    position: relative;
+    z-index: 1;
+}


### PR DESCRIPTION
## Summary
- add a dark overlay to the reservation banner background for better text contrast
- keep banner content above the overlay so typography remains visible

## Testing
- Not run (database connection required)


------
https://chatgpt.com/codex/tasks/task_e_68eea9f311b483329d9469363ad57065