### PR TITLE
Add centralized SEO meta helper for consistent link previews

### DIFF
--- a/about.php
+++ b/about.php
@@ -1,11 +1,17 @@
+<?php require_once __DIR__ . '/includes/site_meta.php'; ?>
 <!doctype html>
 <html class="no-js" lang="en">
 
 <head>
     <meta charset="utf-8">
     <meta http-equiv="x-ua-compatible" content="ie=edge">
-    <title>About | St. John the Baptist Parish</title>
-    <meta name="description" content="Learn about the history, mission, and pastoral team of St. John the Baptist Parish.">
+<?php
+    render_site_meta([
+        'title' => 'About | St. John the Baptist Parish',
+        'description' => 'Learn about the history, mission, and pastoral leadership that guide St. John the Baptist Parish in serving the faithful of Tiaong, Quezon.',
+        'image' => '/img/about/about_1.jpg',
+    ]);
+?>
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <link rel="shortcut icon" type="image/x-icon" href="img/favicon.jpg">

--- a/blog.php
+++ b/blog.php
@@ -1,11 +1,18 @@
+<?php require_once __DIR__ . '/includes/site_meta.php'; ?>
 <!doctype html>
-<html class="no-js" lang="zxx">
+<html class="no-js" lang="en">
 
 <head>
     <meta charset="utf-8">
     <meta http-equiv="x-ua-compatible" content="ie=edge">
-    <title>Montana</title>
-    <meta name="description" content="Stories and updates from St. John the Baptist Parish in Tiaong, Quezon.">
+<?php
+    render_site_meta([
+        'title' => 'Parish Stories | St. John the Baptist Parish',
+        'description' => 'Read parish stories, reflections, and announcements from St. John the Baptist Parish in Tiaong, Quezon.',
+        'image' => '/img/post/1.png',
+        'type' => 'article',
+    ]);
+?>
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <!-- <link rel="manifest" href="site.webmanifest"> -->

--- a/contact.php
+++ b/contact.php
@@ -1,11 +1,17 @@
+<?php require_once __DIR__ . '/includes/site_meta.php'; ?>
 <!doctype html>
 <html class="no-js" lang="en">
 
 <head>
     <meta charset="utf-8">
     <meta http-equiv="x-ua-compatible" content="ie=edge">
-    <title>Inquire | St. John the Baptist Parish</title>
-    <meta name="description" content="Inquire with St. John the Baptist Parish in Tiaong, Quezon for reservations, questions, and pastoral support.">
+<?php
+    render_site_meta([
+        'title' => 'Inquire | St. John the Baptist Parish',
+        'description' => 'Reach out to St. John the Baptist Parish for reservations, sacramental requests, and pastoral care support in Tiaong, Quezon.',
+        'image' => '/img/banner/bradcam2.png',
+    ]);
+?>
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <link rel="shortcut icon" type="image/x-icon" href="img/favicon.jpg">

--- a/includes/site_meta.php
+++ b/includes/site_meta.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Helper to render consistent SEO and social sharing meta tags across the site.
+ *
+ * @param array{
+ *     title?: string,
+ *     description?: string,
+ *     url?: string,
+ *     image?: string,
+ *     type?: string
+ * } $overrides
+ */
+function render_site_meta(array $overrides = []): void
+{
+    $defaults = [
+        'title' => 'St. John the Baptist Parish | Tiaong, Quezon',
+        'description' => 'Discover the worship schedule, sacraments, ministries, and community events at St. John the Baptist Parish in Tiaong, Quezon.',
+        'type' => 'website',
+        'image' => '/img/banner/bradcam3.jpg',
+    ];
+
+    $meta = array_merge($defaults, array_filter($overrides, static fn($value) => $value !== null && $value !== ''));
+
+    $meta['url'] = $overrides['url'] ?? current_page_url();
+
+    $canonicalUrl = filter_var($meta['url'], FILTER_SANITIZE_URL) ?: current_page_url();
+
+    $imageUrl = $meta['image'];
+    if (!preg_match('/^https?:\/\//i', $imageUrl)) {
+        $imageUrl = absolute_url($imageUrl);
+    }
+
+    $escapedTitle = htmlspecialchars($meta['title'], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+    $escapedDescription = htmlspecialchars($meta['description'], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+    $escapedUrl = htmlspecialchars($canonicalUrl, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+    $escapedImage = htmlspecialchars($imageUrl, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+    $ogType = htmlspecialchars($meta['type'], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+
+    echo "    <title>{$escapedTitle}</title>\n";
+    echo "    <meta name=\"description\" content=\"{$escapedDescription}\">\n";
+    echo "    <link rel=\"canonical\" href=\"{$escapedUrl}\">\n";
+    echo "    <meta property=\"og:site_name\" content=\"St. John the Baptist Parish\">\n";
+    echo "    <meta property=\"og:type\" content=\"{$ogType}\">\n";
+    echo "    <meta property=\"og:title\" content=\"{$escapedTitle}\">\n";
+    echo "    <meta property=\"og:description\" content=\"{$escapedDescription}\">\n";
+    echo "    <meta property=\"og:url\" content=\"{$escapedUrl}\">\n";
+    echo "    <meta property=\"og:image\" content=\"{$escapedImage}\">\n";
+    echo "    <meta name=\"twitter:card\" content=\"summary_large_image\">\n";
+    echo "    <meta name=\"twitter:title\" content=\"{$escapedTitle}\">\n";
+    echo "    <meta name=\"twitter:description\" content=\"{$escapedDescription}\">\n";
+    echo "    <meta name=\"twitter:image\" content=\"{$escapedImage}\">\n";
+}
+
+function current_page_url(): string
+{
+    $https = $_SERVER['HTTPS'] ?? '';
+    $isSecure = $https === 'on' || $https === '1';
+    $scheme = $isSecure ? 'https' : 'http';
+
+    $host = $_SERVER['HTTP_HOST'] ?? 'stjohnbaptistparish.com';
+    $uri = $_SERVER['REQUEST_URI'] ?? '/';
+
+    return rtrim($scheme . '://' . $host, '/') . $uri;
+}
+
+function absolute_url(string $path): string
+{
+    if (preg_match('/^https?:\/\//i', $path)) {
+        return $path;
+    }
+
+    $base = current_page_url();
+    $parsed = parse_url($base);
+
+    if ($parsed === false) {
+        return $path;
+    }
+
+    $scheme = $parsed['scheme'] ?? 'http';
+    $host = $parsed['host'] ?? 'stjohnbaptistparish.com';
+    $port = isset($parsed['port']) ? ':' . $parsed['port'] : '';
+
+    return rtrim("{$scheme}://{$host}{$port}", '/') . '/' . ltrim($path, '/');
+}

--- a/index.php
+++ b/index.php
@@ -1,5 +1,6 @@
 <?php
 require_once __DIR__ . '/includes/db_connection.php';
+require_once __DIR__ . '/includes/site_meta.php';
 
 /** @var mysqli|null $connection */
 $connection = null;
@@ -61,9 +62,13 @@ try {
 <head>
     <meta charset="utf-8">
     <meta http-equiv="x-ua-compatible" content="ie=edge">
-    <title>St. John the Baptist Parish | Tiaong, Quezon</title>
-    <meta name="description"
-        content="St. John the Baptist Parish in Tiaong, Quezon is a welcoming Catholic community offering worship, sacraments, and pastoral care.">
+<?php
+    render_site_meta([
+        'title' => 'St. John the Baptist Parish | Tiaong, Quezon',
+        'description' => 'Welcome to St. John the Baptist Parish in Tiaong, Quezon—discover Mass schedules, sacraments, parish news, and ways to get involved with the community.',
+        'image' => '/img/banner/banner2.png',
+    ]);
+?>
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <!-- <link rel="manifest" href="site.webmanifest"> -->

--- a/rooms.php
+++ b/rooms.php
@@ -1,11 +1,17 @@
+<?php require_once __DIR__ . '/includes/site_meta.php'; ?>
 <!doctype html>
-<html class="no-js" lang="zxx">
+<html class="no-js" lang="en">
 
 <head>
     <meta charset="utf-8">
     <meta http-equiv="x-ua-compatible" content="ie=edge">
-    <title>Montana</title>
-    <meta name="description" content="Discover highlights and ministries at St. John the Baptist Parish in Tiaong, Quezon.">
+<?php
+    render_site_meta([
+        'title' => 'Ministries & Highlights | St. John the Baptist Parish',
+        'description' => 'Browse ministries, community highlights, and featured events that bring the St. John the Baptist Parish family together.',
+        'image' => '/img/offers/1.png',
+    ]);
+?>
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <!-- <link rel="manifest" href="site.webmanifest"> -->

--- a/schedule.php
+++ b/schedule.php
@@ -1,12 +1,17 @@
+<?php require_once __DIR__ . '/includes/site_meta.php'; ?>
 <!doctype html>
 <html class="no-js" lang="en">
 
 <head>
     <meta charset="utf-8">
     <meta http-equiv="x-ua-compatible" content="ie=edge">
-    <title>Schedule | St. John the Baptist Parish</title>
-    <meta name="description"
-        content="View the parish schedule and upcoming sacramental celebrations at St. John the Baptist Parish in Tiaong, Quezon.">
+<?php
+    render_site_meta([
+        'title' => 'Schedule | St. John the Baptist Parish',
+        'description' => 'Stay up to date on Mass times, novenas, and special celebrations happening at St. John the Baptist Parish in Tiaong, Quezon.',
+        'image' => '/img/banner/bradcam3.jpg',
+    ]);
+?>
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <link rel="shortcut icon" type="image/x-icon" href="img/favicon.jpg">

--- a/services.php
+++ b/services.php
@@ -1,11 +1,17 @@
+<?php require_once __DIR__ . '/includes/site_meta.php'; ?>
 <!doctype html>
 <html class="no-js" lang="en">
 
 <head>
     <meta charset="utf-8">
     <meta http-equiv="x-ua-compatible" content="ie=edge">
-    <title>Services | St. John the Baptist Parish</title>
-    <meta name="description" content="Explore the sacramental and pastoral services offered by St. John the Baptist Parish in Tiaong, Quezon.">
+<?php
+    render_site_meta([
+        'title' => 'Services | St. John the Baptist Parish',
+        'description' => 'Explore sacramental celebrations, pastoral services, and community support offered by St. John the Baptist Parish in Tiaong, Quezon.',
+        'image' => '/img/banner/bradcam.png',
+    ]);
+?>
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <link rel="shortcut icon" type="image/x-icon" href="img/favicon.jpg">

--- a/single-blog.php
+++ b/single-blog.php
@@ -1,11 +1,18 @@
+<?php require_once __DIR__ . '/includes/site_meta.php'; ?>
 <!doctype html>
-<html class="no-js" lang="zxx">
+<html class="no-js" lang="en">
 
 <head>
    <meta charset="utf-8">
    <meta http-equiv="x-ua-compatible" content="ie=edge">
-   <title>Montana</title>
-   <meta name="description" content="Read reflections and news from St. John the Baptist Parish in Tiaong, Quezon.">
+<?php
+    render_site_meta([
+        'title' => 'Parish Reflection | St. John the Baptist Parish',
+        'description' => 'Dive deeper into the faith with reflections and stories from St. John the Baptist Parish in Tiaong, Quezon.',
+        'image' => '/img/post/2.png',
+        'type' => 'article',
+    ]);
+?>
    <meta name="viewport" content="width=device-width, initial-scale=1">
 
    <!-- <link rel="manifest" href="site.webmanifest"> -->


### PR DESCRIPTION
## Summary
- add a reusable helper that renders consistent SEO, Open Graph, and Twitter meta tags
- update core public-facing pages to use the helper with page-specific descriptions and images for rich previews

## Testing
- php -l includes/site_meta.php
- php -l index.php
- php -l about.php
- php -l contact.php
- php -l services.php
- php -l rooms.php
- php -l schedule.php
- php -l blog.php
- php -l single-blog.php

------
https://chatgpt.com/codex/tasks/task_e_68eeac3b540483328ae2929931b86a10